### PR TITLE
クエリの同期検索Find()機能追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ dependencies {
     testImplementation 'org.yaml:snakeyaml:1.17'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
     testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
     def lifecycle_version = "1.1.1"
     testImplementation "android.arch.core:core-testing:$lifecycle_version"
     def coroutines_version = '1.3.9' //Kotlin coroutines用ライブラリ(async, await)のバージョン

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBConnection.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBConnection.kt
@@ -78,26 +78,16 @@ class NCMBConnection(request: NCMBRequest) {
                 val client = OkHttpClient()
                 val JSON = "application/json; charset=utf-8".toMediaTypeOrNull()
 
-                println("Request Info:")
+                println("Request Info (Sync):")
                 println(ncmbRequest.params.toString())
                 println(ncmbRequest.url)
                 println(headers)
                 println(ncmbRequest.query)
 
                 val body: RequestBody = RequestBody.create(JSON, ncmbRequest.params.toString())
-                val url = Uri.parse(ncmbRequest.url)
-                    .buildUpon()
-
-                for (key in ncmbRequest.query.keys()){
-                    val value = ncmbRequest.query.get(key) as String
-                    val valueConverted = URLEncoder.encode(value, "utf-8") //Encode for URL
-                    url.appendQueryParameter(key, valueConverted)
-                }
-                url.build()
-
                 var request: Request
                 synchronized(lock) {
-                    request = request(ncmbRequest.method, URL(url.toString()), headers, body)
+                    request = request(ncmbRequest.method, URL(ncmbRequest.url), headers, body)
                 }
                 val response = client.newCall(request).execute()
                 ncmbResponse = NCMBResponseBuilder.build(response)
@@ -118,7 +108,7 @@ class NCMBConnection(request: NCMBRequest) {
         val client = OkHttpClient()
         val JSON = "application/json; charset=utf-8".toMediaTypeOrNull()
 
-        println("Request Info:")
+        println("Request Info(Async):")
         println(ncmbRequest.params.toString())
         println(ncmbRequest.url)
         println(headers)

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObject.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObject.kt
@@ -204,4 +204,10 @@ open class NCMBObject : NCMBBase {
             deleteCallback.done(ex)
         }
     }
+
+    companion object {
+        fun getServiceInstance(): NCMBObjectService {
+            return NCMBObjectService()
+        }
+    }
 }

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObject.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObject.kt
@@ -205,9 +205,4 @@ open class NCMBObject : NCMBBase {
         }
     }
 
-    companion object {
-        fun getServiceInstance(): NCMBObjectService {
-            return NCMBObjectService()
-        }
-    }
 }

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -303,6 +303,9 @@ class NCMBObjectService() : NCMBService() {
             is NCMBResponse.Success -> {
                 listObj = createSearchResponseList(className, response.data)
             }
+            is NCMBResponse.Failure -> {
+                throw response.resException
+            }
         }
         return listObj
     }

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -286,17 +286,18 @@ class NCMBObjectService() : NCMBService() {
     }
 
 
-//    /**　TODO:
-//     * Searching JSONObject data from NIFCLOUD mobile backend
-//     * @param className Datastore class name which to search the object
-//     * @param conditions JSONObject of search conditions
-//     * @return List of NCMBObject of search results
-//     * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
-//     */
-//    @Throws(NCMBException::class)
-//    fun findObjects(className: String, conditions: JSONObject?): List<*>? {
-//    }
-//
+    /**　
+     * Searching JSONObject data from NIFCLOUD mobile backend
+     * @param className Datastore class name which to search the object
+     * @param query JSONObject of search conditions
+     * @return List of NCMBObject of search results
+     * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
+     */
+    @Throws(NCMBException::class)
+    fun findObjects(className: String, query: JSONObject?): List<Any> {
+        return emptyList()
+    }
+
     /**
      * Searching JSONObject data to NIFCLOUD mobile backend in background thread
      * @param className Datastore class name which to search the object

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -294,8 +294,17 @@ class NCMBObjectService() : NCMBService() {
      * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
      */
     @Throws(NCMBException::class)
-    fun findObjects(className: String, query: JSONObject?): List<Any> {
-        return emptyList()
+    fun findObjects(className: String, query: JSONObject): List<Any> {
+        //return emptyList()
+        var listObj = listOf<NCMBObject>()
+        val reqParam = findObjectParams(className, query)
+        val response = sendRequest(reqParam)
+        when (response) {
+            is NCMBResponse.Success -> {
+                listObj = createSearchResponseList(className, response.data)
+            }
+        }
+        return listObj
     }
 
     /**

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -27,7 +27,7 @@ import org.json.JSONObject
  * SDK handler is also set here.
  *
  */
-class NCMBObjectService() : NCMBService() {
+class NCMBObjectService() : NCMBService(), NCMBServiceInterface<NCMBObject> {
     val SERVICE_PATH = "classes/"
 
     /**
@@ -294,7 +294,7 @@ class NCMBObjectService() : NCMBService() {
      * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
      */
     @Throws(NCMBException::class)
-    fun findObjects(className: String, query: JSONObject): List<NCMBObject> {
+    override fun findObjects(className: String, query: JSONObject): List<NCMBObject> {
         //return emptyList()
         var listObj = listOf<NCMBObject>()
         val reqParam = findObjectParams(className, query)
@@ -316,7 +316,7 @@ class NCMBObjectService() : NCMBService() {
      * @param query JSONObject of search conditions
      * @param callback callback for after object search
      */
-    fun findObjectsInBackground(
+    override fun findObjectsInBackground(
         className: String,
         query: JSONObject,
         findCallback: NCMBCallback

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -294,7 +294,7 @@ class NCMBObjectService() : NCMBService(), NCMBServiceInterface<NCMBObject> {
      * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
      */
     @Throws(NCMBException::class)
-    override fun findObjects(className: String, query: JSONObject): List<NCMBObject> {
+    override fun find(className: String, query: JSONObject): List<NCMBObject> {
         //return emptyList()
         var listObj = listOf<NCMBObject>()
         val reqParam = findObjectParams(className, query)
@@ -316,7 +316,7 @@ class NCMBObjectService() : NCMBService(), NCMBServiceInterface<NCMBObject> {
      * @param query JSONObject of search conditions
      * @param callback callback for after object search
      */
-    override fun findObjectsInBackground(
+    override fun findInBackground(
         className: String,
         query: JSONObject,
         findCallback: NCMBCallback

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBObjectService.kt
@@ -294,7 +294,7 @@ class NCMBObjectService() : NCMBService() {
      * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
      */
     @Throws(NCMBException::class)
-    fun findObjects(className: String, query: JSONObject): List<Any> {
+    fun findObjects(className: String, query: JSONObject): List<NCMBObject> {
         //return emptyList()
         var listObj = listOf<NCMBObject>()
         val reqParam = findObjectParams(className, query)

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -27,8 +27,15 @@ import java.util.Date
  * NCMBQuery is used to search data from NIFCLOUD mobile backend
  */
 
-class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
+//プライベートコンストラクターとしてcompanion object内にあるfor〇〇メソッドを用いて、インスタンスを取得する
+class NCMBQuery<T : NCMBObject> private constructor(val mClassName: String, val service:NCMBServiceInterface<T>){
     private var mWhereConditions: JSONObject = JSONObject()
+
+    companion object {
+        fun forObject(className: String): NCMBQuery<NCMBObject> {
+            return NCMBQuery<NCMBObject>(className, NCMBObjectService())
+        }
+    }
 
 
     /**　TODO
@@ -38,15 +45,7 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
      */
     @Throws(NCMBException::class)
     fun find(): List<T> {
-        when (mClassName) {
-//TODO
-//          "user" -> {
-//                return NCMBUser.getServiceInstance().findObjects(mClassName, query) as List<T>
-//            }
-            else -> {
-                return NCMBObject.getServiceInstance().findObjects(mClassName, query) as List<T>
-            }
-        }
+        return service.findObjects(mClassName, query)
     }
 
     /**
@@ -54,20 +53,7 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
      * @param callback executed callback after data search
      */
     fun findInBackground(findCallback: NCMBCallback) {
-        if (mClassName == "user") {
-              //TODO
-//            NCMBUser.getServiceInstance().findUserInBackground(conditions, object : SearchUserCallback() {
-//                fun done(users: ArrayList<NCMBUser>?, e: NCMBException?) {
-//                    callback.done(users as List<T>?, e)
-//                }
-//            })
-        } else {
-            //データストアの検索
-            NCMBObject.getServiceInstance().findObjectsInBackground(
-                mClassName,
-                query,
-                findCallback)
-        }
+        service.findObjectsInBackground(mClassName, query, findCallback)
     }
 
     /**

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -36,14 +36,14 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
      * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
      */
     @Throws(NCMBException::class)
-    fun find(): List<Any> {
+    fun find(): List<T> {
 //        TODO
 //        if (mClassName == "user") {
 //            val userServ = NCMBUserService()
 //            userServ.findUser(conditions) as List<T>
 //        } else
         val objServ = NCMBObjectService()
-        return objServ.findObjects(mClassName, query)
+        return objServ.findObjects(mClassName, query) as List<T>
     }
 
     /**

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -45,7 +45,7 @@ class NCMBQuery<T : NCMBObject> private constructor(val mClassName: String, val 
      */
     @Throws(NCMBException::class)
     fun find(): List<T> {
-        return service.findObjects(mClassName, query)
+        return service.find(mClassName, query)
     }
 
     /**
@@ -53,7 +53,7 @@ class NCMBQuery<T : NCMBObject> private constructor(val mClassName: String, val 
      * @param callback executed callback after data search
      */
     fun findInBackground(findCallback: NCMBCallback) {
-        service.findObjectsInBackground(mClassName, query, findCallback)
+        service.findInBackground(mClassName, query, findCallback)
     }
 
     /**

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -30,21 +30,21 @@ import java.util.Date
 class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
     private var mWhereConditions: JSONObject = JSONObject()
 
-//    /**　TODO
-//     * search data from NIFCLOUD mobile backend
-//     * @return NCMBObject(include extend class) list of search result
-//     * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
-//     */
-//    @Throws(NCMBException::class)
-//    fun find(): List<T> {
-//        return if (mClassName == "user") {
+    /**　TODO
+     * search data from NIFCLOUD mobile backend
+     * @return NCMBObject(include extend class) list of search result
+     * @throws NCMBException exception sdk internal or NIFCLOUD mobile backend
+     */
+    @Throws(NCMBException::class)
+    fun find(): List<Any> {
+//        TODO
+//        if (mClassName == "user") {
 //            val userServ = NCMBUserService()
 //            userServ.findUser(conditions) as List<T>
-//        } else {
-//            val objServ = NCMBObjectService()
-//            objServ.findObject(mClassName, conditions)
-//        //}
-//    }
+//        } else
+        val objServ = NCMBObjectService()
+        return objServ.findObjects(mClassName, query)
+    }
 
     /**
      * search data from NIFCLOUD mobile backend asynchronously

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -30,6 +30,7 @@ import java.util.Date
 class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
     private var mWhereConditions: JSONObject = JSONObject()
 
+
     /**　TODO
      * search data from NIFCLOUD mobile backend
      * @return NCMBObject(include extend class) list of search result
@@ -37,13 +38,15 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
      */
     @Throws(NCMBException::class)
     fun find(): List<T> {
-//        TODO
-//        if (mClassName == "user") {
-//            val userServ = NCMBUserService()
-//            userServ.findUser(conditions) as List<T>
-//        } else
-        val objServ = NCMBObjectService()
-        return objServ.findObjects(mClassName, query) as List<T>
+        when (mClassName) {
+//TODO
+//          "user" -> {
+//                return NCMBUser.getServiceInstance().findObjects(mClassName, query) as List<T>
+//            }
+            else -> {
+                return NCMBObject.getServiceInstance().findObjects(mClassName, query) as List<T>
+            }
+        }
     }
 
     /**
@@ -53,16 +56,14 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
     fun findInBackground(findCallback: NCMBCallback) {
         if (mClassName == "user") {
               //TODO
-//            val userServ = NCMBUserService()
-//            userServ.findUserInBackground(conditions, object : SearchUserCallback() {
+//            NCMBUser.getServiceInstance().findUserInBackground(conditions, object : SearchUserCallback() {
 //                fun done(users: ArrayList<NCMBUser>?, e: NCMBException?) {
 //                    callback.done(users as List<T>?, e)
 //                }
 //            })
         } else {
             //データストアの検索
-            val objService = NCMBObjectService()
-            objService.findObjectsInBackground(
+            NCMBObject.getServiceInstance().findObjectsInBackground(
                 mClassName,
                 query,
                 findCallback)
@@ -114,5 +115,6 @@ class NCMBQuery<T : NCMBBase?>(private val mClassName: String) {
     init {
         mWhereConditions = JSONObject()
     }
+
 }
 

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBService.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBService.kt
@@ -175,4 +175,5 @@ open class NCMBService {
         return queryItemlist.joinToString(separator = "&")
     }
 
+
 }

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBServiceInterface.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBServiceInterface.kt
@@ -1,0 +1,10 @@
+package com.nifcloud.mbaas.core
+
+import org.json.JSONObject
+
+interface NCMBServiceInterface<T:NCMBObject> {
+
+    fun findObjects(className: String, query:JSONObject): List<T>
+
+    fun findObjectsInBackground( className: String, query:JSONObject, findCallback: NCMBCallback)
+}

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBServiceInterface.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBServiceInterface.kt
@@ -4,7 +4,7 @@ import org.json.JSONObject
 
 interface NCMBServiceInterface<T:NCMBObject> {
 
-    fun findObjects(className: String, query:JSONObject): List<T>
+    fun find(className: String, query:JSONObject): List<T>
 
-    fun findObjectsInBackground( className: String, query:JSONObject, findCallback: NCMBCallback)
+    fun findInBackground( className: String, query:JSONObject, findCallback: NCMBCallback)
 }

--- a/src/main/java/com/nifcloud/mbaas/core/NCMBUser.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBUser.kt
@@ -418,4 +418,10 @@ open class NCMBUser: NCMBObject {
         val objService = NCMBUserService()
         objService.logoutUser()
     }
+
+    companion object {
+        fun getServiceInstance(): NCMBUserService {
+            return NCMBUserService()
+        }
+    }
 }

--- a/src/test/assets/json_error/E429002_error_response.json
+++ b/src/test/assets/json_error/E429002_error_response.json
@@ -1,0 +1,1 @@
+{"code":"E429002","error":"Too many requests."}

--- a/src/test/assets/json_error/E500001_error_response.json
+++ b/src/test/assets/json_error/E500001_error_response.json
@@ -1,0 +1,1 @@
+{"code":"E500001","error":"System error."}

--- a/src/test/assets/json_error/E503001_error_response.json
+++ b/src/test/assets/json_error/E503001_error_response.json
@@ -1,0 +1,1 @@
+{"code":"E503001","error":"Service unavailable."}

--- a/src/test/assets/yaml/mbaas_error.yml
+++ b/src/test/assets/yaml/mbaas_error.yml
@@ -25,3 +25,24 @@ request:
 response:
     status: 404
     file: valid_get_logout_error_response.json
+---
+request:
+    url: /2013-09-01/classes/TestClass503
+    method: GET
+response:
+    status: 503
+    file: E503001_error_response.json
+---
+request:
+    url: /2013-09-01/classes/TestClass500
+    method: GET
+response:
+    status: 500
+    file: E500001_error_response.json
+---
+request:
+    url: /2013-09-01/classes/TestClass429
+    method: GET
+response:
+    status: 429
+    file: E429002_error_response.json

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBErrorDispatcher.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBErrorDispatcher.kt
@@ -150,9 +150,9 @@ class NCMBErrorDispatcher: Dispatcher() {
     }
 
     private fun defaultErrorResponse(): MockResponse {
-        return MockResponse().setResponseCode(404)
+        return MockResponse().setResponseCode(500)
             .setHeader("Content-Type", "application/json")
-            .setBody(readJsonResponse("valid_error_response.json"))
+            .setBody(readJsonResponse("E500001_error_response.json"))
     }
 
     /**

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBErrorQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBErrorQueryTest.kt
@@ -66,7 +66,7 @@ class NCMBErrorQueryTest {
     @Throws(Exception::class)
     fun testNCMBObject_DoSearchSync_503error() {
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass503")
+        val query = NCMBQuery.forObject("TestClass503")
         val throwable = assertFails{ val objects = query.find() }
         Assert.assertEquals("Service unavailable.",throwable.message)
     }
@@ -75,7 +75,7 @@ class NCMBErrorQueryTest {
     @Throws(Exception::class)
     fun testNCMBObject_DoSearchSync_500error() {
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass500")
+        val query = NCMBQuery.forObject("TestClass500")
         val throwable = assertFails{ val objects = query.find() }
         Assert.assertEquals("System error.",throwable.message)
     }
@@ -84,7 +84,7 @@ class NCMBErrorQueryTest {
     @Throws(Exception::class)
     fun testNCMBObject_DoSearchSync_429error() {
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass429")
+        val query = NCMBQuery.forObject("TestClass429")
         val throwable = assertFails{ val objects = query.find() }
         Assert.assertEquals("Too many requests.",throwable.message)
     }

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBErrorQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBErrorQueryTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2021 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nifcloud.mbaas.core
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nifcloud.mbaas.core.NCMB
+import com.nifcloud.mbaas.core.NCMBErrorDispatcher
+import com.nifcloud.mbaas.core.NCMBException
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.assertFails
+
+
+/**
+ * 主に通信を行う自動化テストクラス
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = intArrayOf(27), manifest = Config.NONE)
+class NCMBErrorQueryTest {
+
+    private var mServer: MockWebServer = MockWebServer()
+    //Todo background method
+    //private var callbackFlag = false
+
+    @get:Rule
+    val rule: TestRule = InstantTaskExecutorRule()
+    @Before
+    fun setup() {
+        var ncmbDispatcher = NCMBErrorDispatcher()
+        mServer.dispatcher = ncmbDispatcher
+        mServer.start()
+        NCMB.initialize(
+            RuntimeEnvironment.application.getApplicationContext(),
+            "appKey",
+            "cliKey",
+            mServer.url("/").toString(),
+            "2013-09-01"
+        )
+        //Todo background method
+
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testNCMBObject_DoSearchSync_503error() {
+        //TestClassクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClass503")
+        val throwable = assertFails{ val objects = query.find() }
+        Assert.assertEquals("Service unavailable.",throwable.message)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testNCMBObject_DoSearchSync_500error() {
+        //TestClassクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClass500")
+        val throwable = assertFails{ val objects = query.find() }
+        Assert.assertEquals("System error.",throwable.message)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testNCMBObject_DoSearchSync_429error() {
+        //TestClassクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClass429")
+        val throwable = assertFails{ val objects = query.find() }
+        Assert.assertEquals("Too many requests.",throwable.message)
+    }
+
+}

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
@@ -108,4 +108,16 @@ class NCMBQueryTest {
         )
     }
 
+    @Test
+    fun testNCMBObject_DoSearchSync_Equal_OneResult() {
+        //TestClassクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClass")
+        query.whereEqualTo("key", "value");
+        val objects = query.find()
+        Assert.assertEquals(
+            (objects[0] as NCMBObject).getObjectId(),
+            "8FgKqFlH8dZRDrBJ"
+        )
+    }
+
 }

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
@@ -44,7 +44,7 @@ class NCMBQueryTest {
     fun testNCMBObject_DoSearchInBackground_Equal_OneResult() {
         val inBackgroundHelper = NCMBInBackgroundTestHelper() // ヘルパーの初期化
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass")
+        val query = NCMBQuery.forObject("TestClass")
         query.whereEqualTo("key", "value");
         val callback = NCMBCallback { e, objects ->
             inBackgroundHelper["e"] = e
@@ -66,7 +66,7 @@ class NCMBQueryTest {
     fun testNCMBObject_DoSearchInBackground_NoResult() {
         val inBackgroundHelper = NCMBInBackgroundTestHelper() // ヘルパーの初期化
         //TestClassNoDataクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClassNoData")
+        val query = NCMBQuery.forObject("TestClassNoData")
         val callback = NCMBCallback { e, objects ->
             inBackgroundHelper["e"] = e
             inBackgroundHelper["objects"] = objects
@@ -87,7 +87,7 @@ class NCMBQueryTest {
     fun testNCMBObject_DoSearchInBackground_NoSearchCondition_TwoResults() {
         val inBackgroundHelper = NCMBInBackgroundTestHelper() // ヘルパーの初期化
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass")
+        val query = NCMBQuery.forObject("TestClass")
         val callback = NCMBCallback { e, objects ->
             inBackgroundHelper["e"] = e
             inBackgroundHelper["objects"] = objects
@@ -111,7 +111,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_DoSearchSync_Equal_OneResult() {
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass")
+        val query = NCMBQuery.forObject("TestClass")
         query.whereEqualTo("key", "value");
         val objects = query.find()
         Assert.assertEquals(
@@ -123,7 +123,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_DoSearchSync_NoResult() {
         //TestClassNoDataクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClassNoData")
+        val query = NCMBQuery.forObject("TestClassNoData")
         val objects = query.find()
         Assert.assertEquals(
             0,
@@ -134,7 +134,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_DoSearchSync_NoSearchCondition_TwoResults() {
         //TestClassクラスを検索するクエリを作成
-        val query = NCMBQuery<NCMBObject>("TestClass")
+        val query = NCMBQuery.forObject("TestClass")
         val objects = query.find()
         Assert.assertEquals(
             (objects[0] as NCMBObject).getObjectId(),

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
@@ -65,7 +65,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_DoSearchInBackground_NoResult() {
         val inBackgroundHelper = NCMBInBackgroundTestHelper() // ヘルパーの初期化
-        //TestClassクラスを検索するクエリを作成
+        //TestClassNoDataクラスを検索するクエリを作成
         val query = NCMBQuery<NCMBObject>("TestClassNoData")
         val callback = NCMBCallback { e, objects ->
             inBackgroundHelper["e"] = e
@@ -117,6 +117,32 @@ class NCMBQueryTest {
         Assert.assertEquals(
             (objects[0] as NCMBObject).getObjectId(),
             "8FgKqFlH8dZRDrBJ"
+        )
+    }
+
+    @Test
+    fun testNCMBObject_DoSearchSync_NoResult() {
+        //TestClassNoDataクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClassNoData")
+        val objects = query.find()
+        Assert.assertEquals(
+            0,
+            objects.size
+        )
+    }
+
+    @Test
+    fun testNCMBObject_DoSearchSync_NoSearchCondition_TwoResults() {
+        //TestClassクラスを検索するクエリを作成
+        val query = NCMBQuery<NCMBObject>("TestClass")
+        val objects = query.find()
+        Assert.assertEquals(
+            (objects[0] as NCMBObject).getObjectId(),
+            "8FgKqFlH8dZRDrBJ"
+        )
+        Assert.assertEquals(
+            (objects[1] as NCMBObject).getObjectId(),
+            "eQRqoObEZmtrfgzH"
         )
     }
 


### PR DESCRIPTION
## 概要(Summary)

- 利用イメージ
```kotlin
       NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(),applicationKey, clientKey)
        //TestClassクラスを検索するクエリを作成
        val query = NCMBQuery<NCMBObject>("TestClass")
        query.whereEqualTo("key", "value");
        //objects: List<Any>検索結果
        try {
            val objects = query.find()
            println("FIND SUCCESS")
            for (obj: Any in objects) {
                if(obj is NCMBObject) {
                    println(obj.getObjectId())
                }
            }
        }catch(e: NCMBException) {
            print("SEARCH SYNC ERROR, EXCEPTION:" + e.message)
        }
    }

```

## 動作確認手順(Step for Confirmation)

Run the unit test.
