### PR TITLE
OR 検索クエリ対応

### DIFF
--- a/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBQuery.kt
@@ -339,6 +339,22 @@ class NCMBQuery<T : NCMBObject> private constructor(val mClassName: String, val 
         }
     }
 
+    /**
+     * Set the OR conditions to search the data that matches any one of the given query
+     * @param queries condition queries
+     */
+    fun or(queries: Collection<NCMBQuery<*>>) {
+        try {
+            val array = JSONArray()
+            for (query in queries) {
+                val queryJson = query.mWhereConditions
+                array.put(queryJson)
+            }
+            mWhereConditions.put("\$or", array)
+        } catch (e: JSONException) {
+            throw NCMBException(e)
+        }
+    }
 
     /**
      * Constructor
@@ -367,6 +383,7 @@ class NCMBQuery<T : NCMBObject> private constructor(val mClassName: String, val 
         newCondition.put(operand, array)
         return newCondition
     }
+
 
 }
 

--- a/src/test/assets/yaml/mbaas_query.yml
+++ b/src/test/assets/yaml/mbaas_query.yml
@@ -218,6 +218,33 @@ response:
     file: valid_get_include_response.json
 ---
 request:
+    url: /2013-09-01/classes/TestClass
+    method: GET
+    query:
+        where: '{"$or":[{"keyInt":{"$lt":100}},{"keyInt":{"$gt":0}}]}'
+response:
+    status: 200
+    file: valid_search_response_one_obj.json
+---
+request:
+    url: /2013-09-01/classes/TestClass
+    method: GET
+    query:
+        where: '{"$or":[{"keyInt":{"$lt":100}},{"keyInt":{"$gt":0}},{"keyInt":{"$lt":100}}]}'
+response:
+    status: 200
+    file: valid_search_response_no_obj.json
+---
+request:
+    url: /2013-09-01/classes/TestClass
+    method: GET
+    query:
+        where: '{"$or":[{"keyInt":{"$lt":100}}]}'
+response:
+    status: 200
+    file: valid_search_response_all_obj.json
+---
+request:
     url: /2013-09-01/roles
     method: GET
 response:

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
@@ -593,32 +593,60 @@ class NCMBQueryTest {
 
     @Test
     fun testNCMBObject_Or_Success() {
-        var applicationKey =  "APPKEY"
-        var clientKey = "CLIKEY"
-        NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(),applicationKey, clientKey)
-        val query1 = NCMBQuery.forObject("TODO")
+        val query1 = NCMBQuery.forObject("TestClass")
         query1.whereLessThan("keyInt", 100)
-        val query2 = NCMBQuery.forObject("TODO")
+        val query2 = NCMBQuery.forObject("TestClass")
         query2.whereGreaterThan("keyInt", 0)
         val queries: List<NCMBQuery<NCMBObject>> = listOf(query1, query2)
-        val query = NCMBQuery.forObject("TODO")
+        val query = NCMBQuery.forObject("TestClass")
         query.or(queries)
-        query.findInBackground (NCMBCallback { e, objects ->
-            if (e != null) {
-                //エラー時の処理
-                println( "検索に失敗しました。エラー:" + e.message)
-            } else {
-                //成功時の処理
-                println("検索に成功しました。")
-                if(objects is List<*>) {
-                    for (obj:Any? in objects) {
-                        if (obj is NCMBObject) {
-                            println(obj.getObjectId())
-                        }
-                    }
-                }
-            }
-        })
+        val objects = query.find()
+        Assert.assertEquals(
+            1,
+            objects.size
+        )
+        Assert.assertEquals(
+            objects[0].getObjectId(),
+            "8FgKqFlH8dZRDrBJ"
+        )
+    }
+
+    @Test
+    fun testNCMBObject_Or_1query_Success() {
+        val query1 = NCMBQuery.forObject("TestClass")
+        query1.whereLessThan("keyInt", 100)
+        val queries: List<NCMBQuery<NCMBObject>> = listOf(query1)
+        val query = NCMBQuery.forObject("TestClass")
+        query.or(queries)
+        val objects = query.find()
+        Assert.assertEquals(
+            2,
+            objects.size
+        )
+        Assert.assertEquals(
+            objects[0].getObjectId(),
+            "8FgKqFlH8dZRDrBJ"
+        )
+        Assert.assertEquals(
+            objects[1].getObjectId(),
+            "eQRqoObEZmtrfgzH"
+        )
+    }
+
+    @Test
+    fun testNCMBObject_Or_3query_Success() {
+        val query1 = NCMBQuery.forObject("TestClass")
+        query1.whereLessThan("keyInt", 100)
+        val query2 = NCMBQuery.forObject("TestClass")
+        query2.whereGreaterThan("keyInt", 0)
+        val queries: List<NCMBQuery<NCMBObject>> = listOf(query1, query2, query1)
+        val query = NCMBQuery.forObject("TestClass")
+        query.or(queries)
+        val objects = query.find()
+        Assert.assertEquals(
+            0,
+            objects.size
+        )
     }
 
     @Test

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBQueryTest.kt
@@ -122,7 +122,7 @@ class NCMBQueryTest {
     fun testNCMBObject_DoSearchSync_Equal_OneResult() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val objects = query.find()
         Assert.assertEquals(
             objects[0].getObjectId(),
@@ -169,7 +169,7 @@ class NCMBQueryTest {
     fun testSkip_Invalid_value_under0() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val throwable = assertFails { query.skip = -1 }
         Assert.assertEquals("Need to set skip value > 0", throwable.message)
     }
@@ -178,7 +178,7 @@ class NCMBQueryTest {
     fun testSkip_valid_value() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         query.skip = 20
         Assert.assertEquals(20, query.skip)
     }
@@ -188,7 +188,7 @@ class NCMBQueryTest {
     fun testLimit_Invalid_value_under0() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val throwable = assertFails { query.limit = -100 }
         Assert.assertEquals("Need to set limit value from 1 to 1000", throwable.message)
     }
@@ -198,7 +198,7 @@ class NCMBQueryTest {
     fun testLimit_Invalid_value_over1000() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val throwable = assertFails { query.limit = 1001 }
         Assert.assertEquals("Need to set limit value from 1 to 1000", throwable.message)
     }
@@ -207,7 +207,7 @@ class NCMBQueryTest {
     fun testLimit_valid_value() {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClass")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         query.limit = 200
         Assert.assertEquals(200, query.limit)
     }
@@ -217,7 +217,7 @@ class NCMBQueryTest {
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClassSkip")
         query.skip = 3
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
 
         val objects = query.find()
         Assert.assertEquals(2,objects.count())
@@ -257,7 +257,7 @@ class NCMBQueryTest {
         val inBackgroundHelper = NCMBInBackgroundTestHelper() // ヘルパーの初期化
         //TestClassクラスを検索するクエリを作成
         val query = NCMBQuery.forObject("TestClassCount")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val callback = NCMBCallback { e, number ->
             inBackgroundHelper["e"] = e
             inBackgroundHelper["number"] = number
@@ -343,7 +343,7 @@ class NCMBQueryTest {
     @Test    
     fun testNCMBObject_DoCount_Equal_Success() {
         val query = NCMBQuery.forObject("TestClassCount")
-        query.whereEqualTo("key", "value");
+        query.whereEqualTo("key", "value")
         val number = query.count()
         Assert.assertEquals(
             50,
@@ -374,7 +374,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_NotEqual_Success() {
         val query = NCMBQuery.forObject("TestClassNotEqual")
-        query.whereNotEqualTo("key", "value");
+        query.whereNotEqualTo("key", "value")
         val objects = query.find()
         Assert.assertEquals(
             2,
@@ -413,7 +413,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_GreaterThan_Success() {
         val query = NCMBQuery.forObject("TestClassGreaterThan")
-        query.whereGreaterThan("key", 2);
+        query.whereGreaterThan("key", 2)
         val objects = query.find()
         Assert.assertEquals(
             2,
@@ -452,7 +452,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_GreaterThanOrEqual_Success() {
         val query = NCMBQuery.forObject("TestClassGreaterThanOrEqual")
-        query.whereGreaterThanOrEqualTo("key", 2);
+        query.whereGreaterThanOrEqualTo("key", 2)
         val objects = query.find()
         Assert.assertEquals(
             2,
@@ -491,7 +491,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_LessThan_Success() {
         val query = NCMBQuery.forObject("TestClassLessThan")
-        query.whereLessThan("key", 100);
+        query.whereLessThan("key", 100)
         val objects = query.find()
         Assert.assertEquals(
             2,
@@ -530,7 +530,7 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_LessThanOrEqual_Success() {
         val query = NCMBQuery.forObject("TestClassLessThanOrEqual")
-        query.whereLessThanOrEqualTo("key", 100);
+        query.whereLessThanOrEqualTo("key", 100)
         val objects = query.find()
         Assert.assertEquals(
             2,
@@ -578,8 +578,8 @@ class NCMBQueryTest {
     @Test
     fun testNCMBObject_LessThanOrEqualAndEqual_Success() {
         val query = NCMBQuery.forObject("TestClass")
-        query.whereLessThanOrEqualTo("key", 100);
-        query.whereEqualTo("key", "value");
+        query.whereLessThanOrEqualTo("key", 100)
+        query.whereEqualTo("key", "value")
         val objects = query.find()
         Assert.assertEquals(
             1,
@@ -589,6 +589,36 @@ class NCMBQueryTest {
             objects[0].getObjectId(),
             "8FgKqFlH8dZRDrBJ"
         )
+    }
+
+    @Test
+    fun testNCMBObject_Or_Success() {
+        var applicationKey =  "APPKEY"
+        var clientKey = "CLIKEY"
+        NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(),applicationKey, clientKey)
+        val query1 = NCMBQuery.forObject("TODO")
+        query1.whereLessThan("keyInt", 100)
+        val query2 = NCMBQuery.forObject("TODO")
+        query2.whereGreaterThan("keyInt", 0)
+        val queries: List<NCMBQuery<NCMBObject>> = listOf(query1, query2)
+        val query = NCMBQuery.forObject("TODO")
+        query.or(queries)
+        query.findInBackground (NCMBCallback { e, objects ->
+            if (e != null) {
+                //エラー時の処理
+                println( "検索に失敗しました。エラー:" + e.message)
+            } else {
+                //成功時の処理
+                println("検索に成功しました。")
+                if(objects is List<*>) {
+                    for (obj:Any? in objects) {
+                        if (obj is NCMBObject) {
+                            println(obj.getObjectId())
+                        }
+                    }
+                }
+            }
+        })
     }
 
     @Test


### PR DESCRIPTION
- $or 検索条件対応
https://mbaas.nifcloud.com/doc/current/rest/common/query.html#%E8%A4%87%E5%90%88%E6%9D%A1%E4%BB%B6%E6%A4%9C%E7%B4%A2
- OR 検索を実施

```kt
        val query1 = NCMBQuery.forObject("TODO")
        query1.whereLessThan("keyInt", 100)
        val query2 = NCMBQuery.forObject("TODO")
        query2.whereGreaterThan("keyInt", 0)
        val queries: List<NCMBQuery<NCMBObject>> = listOf(query1, query2)
        val query = NCMBQuery.forObject("TODO")
        query.or(queries)
        query.findInBackground (NCMBCallback { e, objects ->
            if (e != null) {
                //エラー時の処理
                println( "検索に失敗しました。エラー:" + e.message)
            } else {
                //成功時の処理
                println("検索に成功しました。")
                if(objects is List<*>) {
                    for (obj:Any? in objects) {
                        if (obj is NCMBObject) {
                            println(obj.getObjectId())
                        }
                    }
                }
            }
        })
```