### PR TITLE
fix login missing check null password

### DIFF
--- a/src/main/java/com/nifcloud/mbaas/core/NCMBUser.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBUser.kt
@@ -239,7 +239,7 @@ open class NCMBUser: NCMBObject {
     @Throws(NCMBException::class)
     open fun login(): NCMBUser {
         val userService = NCMBUserService()
-        if(!checkExist(USERNAME) || !checkExist(USERNAME)){
+        if(!checkExist(USERNAME) || !checkExist(PASSWORD)){
             throw NCMBException(NCMBException.REQUIRED, "username or password not set")
         }
         return userService.loginByName(userName, password)

--- a/src/test/java/com/nifcloud/mbaas/core/NCMBErrorUserTest.kt
+++ b/src/test/java/com/nifcloud/mbaas/core/NCMBErrorUserTest.kt
@@ -180,6 +180,21 @@ class NCMBErrorUserTest {
     }
 
     @Test
+    @Throws(java.lang.Exception::class)
+    fun login_invalid_null_password() {
+        NCMBUser().clearCachedCurrentUser()
+        val user = NCMBUser()
+        user.userName = "duplicateUser"
+        try {
+            user.login()
+        }
+        catch (e:NCMBException){
+            Assert.assertEquals(NCMBException.REQUIRED, e.code)
+        }
+        Assert.assertNull(NCMBUser().getCurrentUser().getObjectId())
+    }
+
+    @Test
     fun logout_failure_connect_error() {
         NCMB.SESSION_TOKEN = "testToken"
         NCMB.USER_ID = "TestId"


### PR DESCRIPTION
## 概要(Summary)

- Fixed login missing check null password

```java
var user = NCMBUser()
//ユーザー名・パスワードを設定
user.userName = "takanokun" /* ユーザー名 */
try{
    // ユーザー名とパスワードでログイン
    user.login()
    Log.d("success","ログインに成功しました")
}
catch(e:NCMBException){
    // ログインに失敗した場合の処理
    Log.d("failure","ログインに失敗しました ： " + e.message)
}
```

## 動作確認手順(Step for Confirmation)

Run the unit test.
